### PR TITLE
Updated validator to ignore error if not validating

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,9 @@ module.exports = class OpenApiValidator {
                 } = this.event;
                 const httpMethodLower = httpMethod.toLowerCase();
     
-                if (!paths[path] || !paths[path][httpMethodLower]) {
+                if ((!paths[path] || !paths[path][httpMethodLower])
+                    && this.validateRequests
+                    && this.validateResponses) {
                     throw new ValidationError(`The path ${path} could not be found with http method ${httpMethodLower} in the API spec`, 400);
                 }
                 this.config = paths[path][httpMethodLower];


### PR DESCRIPTION
## Description
- Added logic to ignore throwing an error if the path was not found in the openapi documentation given that no request and response validation will be performed.
- Added tests
- Updated docker-compose.yml to include new ENV

## Relates to
- [CP-1475](https://persistolabs.atlassian.net/browse/CP-1475)

## Reviewers
- @louisnk  (merge duty)


