### PR TITLE
Fixed reference error when not validating

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ module.exports = class OpenApiValidator {
                 } = this.event;
                 const httpMethodLower = httpMethod.toLowerCase();
 
-                if (this.validateRequests && this.validateResponses) {
+                if (this.validateRequests || this.validateResponses) {
                     if (!paths[path] || !paths[path][httpMethodLower]) {
                         throw new ValidationError(`The path ${path} could not be found with http method ${httpMethodLower} in the API spec`, 400);
                     }

--- a/src/index.js
+++ b/src/index.js
@@ -43,14 +43,14 @@ module.exports = class OpenApiValidator {
                     queryStringParameters,
                 } = this.event;
                 const httpMethodLower = httpMethod.toLowerCase();
-    
-                if ((!paths[path] || !paths[path][httpMethodLower])
-                    && this.validateRequests
-                    && this.validateResponses) {
-                    throw new ValidationError(`The path ${path} could not be found with http method ${httpMethodLower} in the API spec`, 400);
+
+                if (this.validateRequests && this.validateResponses) {
+                    if (!paths[path] || !paths[path][httpMethodLower]) {
+                        throw new ValidationError(`The path ${path} could not be found with http method ${httpMethodLower} in the API spec`, 400);
+                    }
+                    this.config = paths[path][httpMethodLower];
                 }
-                this.config = paths[path][httpMethodLower];
-    
+                
                 // Validate Requests
                 if (this.validateRequests) {
                     const filteredRequest = this._validateRequests(path, this.event, this.config);


### PR DESCRIPTION
## Description
- Fixed reference error when not validating where setting the config, an undefined path can be used to reference properties in the documentation spec which causes a reference error.

## Reviewers
- @louisnk  (merge duty)
- @vindard 

## Steps to reproduce
- Setup the validator in a lambda as given in the example.
- Set `validateRequests` and `validateResponses` to `false`.
- Setup api gateway with an endpoint that does not exist in the supplied spec.

### Screenshots / other info
...
<img width="961" alt="image" src="https://user-images.githubusercontent.com/9885005/70461263-a68a9680-1a8e-11ea-95d2-e1a8ef5c36c5.png">


