### PR TITLE
Added additional validation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ exports.handler = new OpenApiValidator(options, handler).install();
     - responseErrorTransformer: Function used to transform the body of a request (`argument: response from lambda, statusCode, message; returns: transformed response`). **See note below.
     - responseSuccessTransformer: Function used to transform the body of a request (`argument: response from lambda, statusCode; returns: transformed response`) **See note below
     - roleAuthorizerKey: The key used to access the role property from a user in the event authorizer property. **See example in /examples.
+    - useDefaults: Whether or not to use the default values specified in the api doc if it isn't specified in a request only
     - validateRequests: Whether or not to validate the request body, params, query, headers to the api documentation included (`default: false`)
     - validateResponses: Whether or not to validate the response to the api documentation included (`default: false`)
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ module.exports = class OpenApiValidator {
         this.lambdaTearDown = params.lambdaTearDown;
         this.roleAuthorizerKey = params.roleAuthorizerKey || null;
         this.filterByRole = params.filterByRole || false;
+        this.useDefaults = params.useDefaults || false;
         this.defaultRoleName = params.defaultRoleName || 'default';
         this.config = {};
         this.lambdaBody = lambdaBody;
@@ -166,6 +167,8 @@ module.exports = class OpenApiValidator {
                 this.apiSpec,
                 {
                     removeAdditional: this.removeAdditionalRequestProps,
+                    strictRequired: true,
+                    useDefault: this.useDefaults,
                 },
                 schema);
             const request = {
@@ -193,7 +196,9 @@ module.exports = class OpenApiValidator {
             const responseValidator = new ResponseValidator(
                 this.apiSpec,
                 {
+                    nullable: true,
                     removeAdditional: this.removeAdditionalResponseProps,
+                    strictRequired: 'log',
                 },
                 schema,
                 role);

--- a/src/index.js
+++ b/src/index.js
@@ -166,6 +166,7 @@ module.exports = class OpenApiValidator {
             const requestValidator = new RequestValidator(
                 this.apiSpec,
                 {
+                    nullable: true,
                     removeAdditional: this.removeAdditionalRequestProps,
                     strictRequired: true,
                     useDefault: this.useDefaults,


### PR DESCRIPTION
Fixes [CP-3301](https://persistolabs.atlassian.net/browse/CP-3301)

## Description
- Added validation options to use the default values specified in an api spec if a value isn't added to the request body, updated config to throw errors if required items aren't set in requests, but only log a warning if it isn't returned in the response body.

## Reviewers
- @louisnk  (merge duty)
- @TommyChums 

## Steps to reproduce
- With validateRequests and validateResponses set to `true`, update the docs to include default values for optional properties in an api request and set required properties for both requests and response.
- Create a request without including an optional value and ensure that the default value is used.
- Create a request without including a required item and expect that the validator throw an error.
- Create a request that has a response that leave out required properties as defied in the doc and expect the validator to log a warning in Cloudwatch.

