### PR TITLE
Undo validating request after transforming data

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,13 @@ module.exports = class OpenApiValidator {
                     }
                 }
                 this.event.routeConfig = this.config;
+                // Validate Requests
+                if (this.validateRequests) {
+                    const filteredRequest = this._validateRequests(path, this.event, this.config);
+                    
+                    // Replace the properties of the event with the filtered ones (body, queryParams, pathParams)
+                    Object.assign(this.event, filteredRequest);
+                }
                 // Transform Requests
                 if (this.requestBodyTransformer) {
                     const transformedBody = this.requestBodyTransformer(body || {});
@@ -82,13 +89,6 @@ module.exports = class OpenApiValidator {
                 if (this.requestQueryTransformer) {
                     const transformedQuery = this.requestQueryTransformer(queryStringParameters || {});
                     this.event.queryStringParameters = transformedQuery;
-                }
-                // Validate Requests
-                if (this.validateRequests) {
-                    const filteredRequest = this._validateRequests(path, this.event, this.config);
-                    
-                    // Replace the properties of the event with the filtered ones (body, queryParams, pathParams)
-                    Object.assign(this.event, filteredRequest);
                 }
 
                 if (this.lambdaSetup) {


### PR DESCRIPTION
Fixes [CP-3301](https://persistolabs.atlassian.net/browse/CP-3301)

## Description
- Undo validating request after transforming data. This enforces that inputs should be in a consistent format as specified by the developer through the api docs.

## Reviewers
- @louisnk  (merge duty)
